### PR TITLE
fix: tags not appending

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smartweaver/slick-transaction",
   "version": "0.0.12",
-  "versionBuildDate": "20240604.1307",
+  "versionBuildDate": "202340731.1624",
   "description": "Slick builder APIs for creating Arweave transactions",
   "author": "Eric Crooks <eric.crooks.github@gmail.com> (https://crookse.com)",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartweaver/slick-transaction",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "versionBuildDate": "20240604.1307",
   "description": "Slick builder APIs for creating Arweave transactions",
   "author": "Eric Crooks <eric.crooks.github@gmail.com> (https://crookse.com)",

--- a/src/core/AbstractTransactionBuilder.ts
+++ b/src/core/AbstractTransactionBuilder.ts
@@ -94,7 +94,7 @@ export abstract class AbstractTransactionBuilder<Tx extends Transaction = any> {
    */
   tags(tags: Record<string, string> = {}) {
     this.transaction_tags = {
-      ...(this.tags || {}),
+      ...(this.transaction_tags || {}),
       ...tags,
     };
 


### PR DESCRIPTION
## Summary

When using any `.tags()` method, the tags are reset. This means `.action()` methods could have their values removed when `.tags()` is called after it.