### PR TITLE
fix: keep Action tag intact if it exists

### DIFF
--- a/.github/workflows/v0.x.code_validation.yml
+++ b/.github/workflows/v0.x.code_validation.yml
@@ -77,12 +77,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          cd tests/integration/modules/aoconnect
-          pnpm install
-          cd -
-
-          cd tests/integration/standard/with-arweave-js
-          pnpm install
-          cd -
-
-          deno task test:unit --no-watch
+          deno task test --no-watch

--- a/deno.json
+++ b/deno.json
@@ -32,6 +32,6 @@
     "build:libs": "deno run --allow-read --allow-write --allow-net ./scripts/doit.ts && pnpm tsup src --format cjs,esm --no-splitting --dts",
     "check:package-json-version": "deno run --allow-read ./scripts/check_package_json_version_for_release.ts",
     "publish:npm": "npm publish --access public",
-    "test:unit": "pnpm vitest"
+    "test": "./scripts/test"
   }
 }

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+(
+  cd tests/integration/modules/aoconnect
+  pnpm install
+  cd -
+
+  cd tests/integration/standard/with-arweave-js
+  pnpm install
+  cd -
+
+  pnpm vitest $@
+)

--- a/src/core/AbstractTransactionBuilder.ts
+++ b/src/core/AbstractTransactionBuilder.ts
@@ -93,9 +93,13 @@ export abstract class AbstractTransactionBuilder<Tx extends Transaction = any> {
    * @returns `this` instance for further method chaining.
    */
   tags(tags: Record<string, string> = {}) {
+    const currentTags = (this.transaction_tags || {});
+    const actionTag = currentTags?.Action;
+
     this.transaction_tags = {
-      ...(this.transaction_tags || {}),
-      ...tags,
+      ...currentTags, // Keep the current tags
+      ...(tags || {}), // Overwrite the current tags if any
+      ...(actionTag ? { Action: actionTag } : {}) // Keep the Action tag if any
     };
 
     return this;

--- a/src/core/AbstractTransactionBuilder.ts
+++ b/src/core/AbstractTransactionBuilder.ts
@@ -93,13 +93,13 @@ export abstract class AbstractTransactionBuilder<Tx extends Transaction = any> {
    * @returns `this` instance for further method chaining.
    */
   tags(tags: Record<string, string> = {}) {
-    const currentTags = (this.transaction_tags || {});
+    const currentTags = this.transaction_tags || {};
     const actionTag = currentTags?.Action;
 
     this.transaction_tags = {
       ...currentTags, // Keep the current tags
       ...(tags || {}), // Overwrite the current tags if any
-      ...(actionTag ? { Action: actionTag } : {}) // Keep the Action tag if any
+      ...(actionTag ? { Action: actionTag } : {}), // Keep the Action tag if any
     };
 
     return this;

--- a/src/modules/aoprocess/TokenProcess.ts
+++ b/src/modules/aoprocess/TokenProcess.ts
@@ -2,8 +2,8 @@ import { DryRun as CuDryRun } from "../aoconnect/units/compute/DryRun.ts";
 import { Message as MuMessage } from "../aoconnect/units/messenger/Message.ts";
 import { Process } from "./Process.ts";
 
-type Message = Omit<MuMessage, "process">
-type DryRun = Omit<CuDryRun, "process">
+type Message = Omit<MuMessage, "process">;
+type DryRun = Omit<CuDryRun, "process">;
 
 export type TokenActions =
   | "Balance"
@@ -27,7 +27,7 @@ export class TokenProcess<
       .dryRun("Balance")
       .tags({
         Target: target,
-      })
+      });
   }
 
   /**
@@ -37,7 +37,7 @@ export class TokenProcess<
    */
   balances(): DryRun {
     return this
-      .dryRun("Balances")
+      .dryRun("Balances");
   }
 
   /**

--- a/src/modules/aoprocess/TokenProcess.ts
+++ b/src/modules/aoprocess/TokenProcess.ts
@@ -1,4 +1,9 @@
+import { DryRun as CuDryRun } from "../aoconnect/units/compute/DryRun.ts";
+import { Message as MuMessage } from "../aoconnect/units/messenger/Message.ts";
 import { Process } from "./Process.ts";
+
+type Message = Omit<MuMessage, "process">
+type DryRun = Omit<CuDryRun, "process">
 
 export type TokenActions =
   | "Balance"
@@ -15,27 +20,24 @@ export class TokenProcess<
    * Send a `Action = "Balance"` message.
    *
    * @param target The target balance in question.
-   * @returns The balance result.
+   * @returns The action builder. You can call `.post()` on it to send it.
    */
-  balance(target: string) {
+  balance(target: string): DryRun {
     return this
-      .action("Balance")
+      .dryRun("Balance")
       .tags({
         Target: target,
       })
-      .post();
   }
 
   /**
    * Send a `Action = "Balances"` message.
    *
-   * @param target The target balance in question.
-   * @returns The balances result.
+   * @returns The action builder. You can call `.post()` on it to send it.
    */
-  balances() {
+  balances(): DryRun {
     return this
-      .action("Balances")
-      .post();
+      .dryRun("Balances")
   }
 
   /**
@@ -79,7 +81,7 @@ export class TokenProcess<
    */
   info() {
     return this
-      .action("Info")
+      .dryRun("Info")
       .post();
   }
 
@@ -108,7 +110,7 @@ export class TokenProcess<
    * // - end of example -
    * ```
    */
-  mint(target: string, quantity: string) {
+  mint(target: string, quantity: string): Message {
     return this
       .action("Mint")
       .tags({

--- a/tests/integration/modules/aoprocess/TokenProcess.test.ts
+++ b/tests/integration/modules/aoprocess/TokenProcess.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test, vi } from "vitest";
+import aoconnect from "@permaweb/aoconnect";
+import { TokenProcess } from "../../../../src/modules/aoprocess/TokenProcess.ts";
+import packageJson from "../../../../package.json";
+
+const expectedSdkName = "@smartweaver/slick-transaction";
+const expectedSdkVersion = packageJson.version + "-" +
+  packageJson.versionBuildDate;
+
+// We do not want to send an actual request through aoconnect, so we return the 
+// args that would be sent to aoconnect's APIs and verify those
+vi.mock("@permaweb/aoconnect", () => {
+  return {
+    default: {
+      dryrun: (...args: any[]) => {
+        return args;
+      },
+
+      message: (...args: any[]) => {
+        return args;
+      },
+
+      result: (...args: any[]) => {
+        return args;
+      },
+
+      results: (...args: any[]) => {
+        return args;
+      },
+
+      spawn: (...args: any[]) => {
+        return args;
+      },
+    },
+  };
+});
+
+const dSigner = () => {
+  return "some-data-item-signer";
+};
+
+const token = new TokenProcess(aoconnect, "MyProcessId1337")
+
+describe("TokenProcess", () => {
+
+  test("balance()", async () => {
+    const result = await token
+      .balance("some-target-address")
+      .post()
+
+    expect(result).toStrictEqual([
+      {
+        process: "MyProcessId1337",
+        tags: [
+          { name: "Action", value: "Balance" },
+          { name: "Target", value: "some-target-address" },
+          { name: "SDK-Name", value: expectedSdkName },
+          { name: "SDK-Version", value: expectedSdkVersion },
+        ],
+      },
+    ]);
+  });
+
+  test("balances()", async () => {
+    const result = await token
+      .balances()
+      .post()
+
+    expect(result).toStrictEqual([
+      {
+        process: "MyProcessId1337",
+        tags: [
+          { name: "Action", value: "Balances" },
+          { name: "SDK-Name", value: expectedSdkName },
+          { name: "SDK-Version", value: expectedSdkVersion },
+        ],
+      },
+    ]);
+  });
+
+  test("burn()", async () => {
+    const result = await token
+      .burn(
+        "some-target",
+        "670000000000000"
+      )
+      .tags({
+        "X-Some-Tag": "some-tag-value",
+      })
+      .dataItemSigner(dSigner)
+      .post()
+
+    expect(result).toStrictEqual([
+      {
+        process: "MyProcessId1337",
+        signer: dSigner,
+        tags: [
+          { name: "Action", value: "Burn" },
+          { name: "Target", value: "some-target" },
+          { name: "Quantity", value: "670000000000000" },
+          { name: "X-Some-Tag", value: "some-tag-value" },
+          { name: "SDK-Name", value: expectedSdkName },
+          { name: "SDK-Version", value: expectedSdkVersion },
+        ],
+      },
+    ]);
+  });
+
+  test("mint()", async () => {
+    const result = await token
+      .mint(
+        "some-target",
+        "670000000000000"
+      )
+      .tags({
+        "X-Some-Tag": "some-tag-value",
+      })
+      .dataItemSigner(dSigner)
+      .post()
+
+    expect(result).toStrictEqual([
+      {
+        process: "MyProcessId1337",
+        signer: dSigner,
+        tags: [
+          { name: "Action", value: "Mint" },
+          { name: "Target", value: "some-target" },
+          { name: "Quantity", value: "670000000000000" },
+          { name: "X-Some-Tag", value: "some-tag-value" },
+          { name: "SDK-Name", value: expectedSdkName },
+          { name: "SDK-Version", value: expectedSdkVersion },
+        ],
+      },
+    ]);
+  });
+
+  test("transfer()", async () => {
+    const result = await token
+      .transfer(
+        "some-target",
+        "670000000000000"
+      )
+      .tags({
+        "X-Some-Tag": "some-tag-value",
+      })
+      .dataItemSigner(dSigner)
+      .post()
+
+    expect(result).toStrictEqual([
+      {
+        process: "MyProcessId1337",
+        signer: dSigner,
+        tags: [
+          { name: "Action", value: "Transfer" },
+          { name: "Recipient", value: "some-target" },
+          { name: "Quantity", value: "670000000000000" },
+          { name: "X-Some-Tag", value: "some-tag-value" },
+          { name: "SDK-Name", value: expectedSdkName },
+          { name: "SDK-Version", value: expectedSdkVersion },
+        ],
+      },
+    ]);
+  });
+});

--- a/tests/integration/modules/aoprocess/TokenProcess.test.ts
+++ b/tests/integration/modules/aoprocess/TokenProcess.test.ts
@@ -7,7 +7,7 @@ const expectedSdkName = "@smartweaver/slick-transaction";
 const expectedSdkVersion = packageJson.version + "-" +
   packageJson.versionBuildDate;
 
-// We do not want to send an actual request through aoconnect, so we return the 
+// We do not want to send an actual request through aoconnect, so we return the
 // args that would be sent to aoconnect's APIs and verify those
 vi.mock("@permaweb/aoconnect", () => {
   return {
@@ -39,14 +39,13 @@ const dSigner = () => {
   return "some-data-item-signer";
 };
 
-const token = new TokenProcess(aoconnect, "MyProcessId1337")
+const token = new TokenProcess(aoconnect, "MyProcessId1337");
 
 describe("TokenProcess", () => {
-
   test("balance()", async () => {
     const result = await token
       .balance("some-target-address")
-      .post()
+      .post();
 
     expect(result).toStrictEqual([
       {
@@ -64,7 +63,7 @@ describe("TokenProcess", () => {
   test("balances()", async () => {
     const result = await token
       .balances()
-      .post()
+      .post();
 
     expect(result).toStrictEqual([
       {
@@ -82,13 +81,13 @@ describe("TokenProcess", () => {
     const result = await token
       .burn(
         "some-target",
-        "670000000000000"
+        "670000000000000",
       )
       .tags({
         "X-Some-Tag": "some-tag-value",
       })
       .dataItemSigner(dSigner)
-      .post()
+      .post();
 
     expect(result).toStrictEqual([
       {
@@ -110,13 +109,13 @@ describe("TokenProcess", () => {
     const result = await token
       .mint(
         "some-target",
-        "670000000000000"
+        "670000000000000",
       )
       .tags({
         "X-Some-Tag": "some-tag-value",
       })
       .dataItemSigner(dSigner)
-      .post()
+      .post();
 
     expect(result).toStrictEqual([
       {
@@ -138,13 +137,13 @@ describe("TokenProcess", () => {
     const result = await token
       .transfer(
         "some-target",
-        "670000000000000"
+        "670000000000000",
       )
       .tags({
         "X-Some-Tag": "some-tag-value",
       })
       .dataItemSigner(dSigner)
-      .post()
+      .post();
 
     expect(result).toStrictEqual([
       {

--- a/tests/integration/modules/aoprocess/package.json
+++ b/tests/integration/modules/aoprocess/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "integration-modules-aoprocess",
+  "version": "1.0.0",
+  "license": "GPL-3.0",
+  "devDependencies": {
+    "@drashland/rhum": "^2.2.0",
+    "@permaweb/aoconnect": "~0.x"
+  }
+}


### PR DESCRIPTION
## Summary

- Prevent the `Action` tag from being removed
- Update test command to use script (also use this in CI)
- Improve typings for TokenProcess