### PR TITLE
feat(core)!: deprecate .attributes()

### DIFF
--- a/src/core/AbstractTransactionBuilder.ts
+++ b/src/core/AbstractTransactionBuilder.ts
@@ -31,25 +31,6 @@ export abstract class AbstractTransactionBuilder<Tx extends Transaction = any> {
   }
 
   /**
-   * Set the transaction's attributes using the given attributes. This method
-   * exists to set attributes in one go as opposed to doing it with chained
-   * methods. An example use case is if a transaction is received in JSON fromat
-   * and can be used to set most of the fields in this builder. Instead of
-   * adding the fields one by one with chained methods, it can be done using
-   * this single method.
-   * @param attributes The transaction attributes in question.
-   * @returns `this` instance for further method chaining.
-   */
-  attributes(attributes: Partial<Tx> = {}) {
-    this.transaction = {
-      ...this.transaction,
-      ...attributes,
-    };
-
-    return this;
-  }
-
-  /**
    * Build the transaction.
    * @returns The built transaction.
    */

--- a/src/standard/transactions/format-1/TransactionBuilder.ts
+++ b/src/standard/transactions/format-1/TransactionBuilder.ts
@@ -1,7 +1,24 @@
 import { AbstractTransactionBuilder } from "../../../core/AbstractTransactionBuilder.ts";
 import { TransactionFormat1 as Tx1 } from "./interfaces/TransactionFormat1.ts";
+import { Transaction } from "./Transaction.ts";
 
 export class TransactionBuilder extends AbstractTransactionBuilder<Tx1> {
+  /**
+   * @deprecated on 2024-08-17. Use {@link Transaction.from}.
+   *
+   * Set the transaction's attributes using the given attributes. This method
+   * exists to set attributes in one go as opposed to doing it with chained
+   * methods. An example use case is if a transaction is received in JSON fromat
+   * and can be used to set most of the fields in this builder. Instead of
+   * adding the fields one by one with chained methods, it can be done using
+   * this single method.
+   * @param attributes The transaction attributes in question.
+   * @returns `this` instance for further method chaining.
+   */
+  attributes(attributes: Partial<Tx1> = {}) {
+    return Transaction.from(attributes);
+  }
+
   override build(): Tx1 {
     return {
       ...super.build(),

--- a/src/standard/transactions/format-2/TransactionBuilder.ts
+++ b/src/standard/transactions/format-2/TransactionBuilder.ts
@@ -1,7 +1,24 @@
 import { AbstractTransactionBuilder } from "../../../core/AbstractTransactionBuilder.ts";
 import { TransactionFormat2 as Tx2 } from "./interfaces/TransactionFormat2.ts";
+import { Transaction } from "./Transaction.ts";
 
 export class TransactionBuilder extends AbstractTransactionBuilder<Tx2> {
+  /**
+   * @deprecated on 2024-08-17. Use {@link Transaction.from}.
+   *
+   * Set the transaction's attributes using the given attributes. This method
+   * exists to set attributes in one go as opposed to doing it with chained
+   * methods. An example use case is if a transaction is received in JSON fromat
+   * and can be used to set most of the fields in this builder. Instead of
+   * adding the fields one by one with chained methods, it can be done using
+   * this single method.
+   * @param attributes The transaction attributes in question.
+   * @returns `this` instance for further method chaining.
+   */
+  attributes(attributes: Partial<Tx2> = {}) {
+    return Transaction.from(attributes);
+  }
+
   override build(): Tx2 {
     return {
       ...super.build(),


### PR DESCRIPTION
## Summary

- `.attributes()` method is deprecated
- `.attributes()` method is moved to `format-1` and `format-2` `TransactionBuilder` classes and promotes `.from()` method usage (since they do the same thing and `.from()` is more stable)